### PR TITLE
Make org-code -> ms-orange and org-verbatim -> ms-lightorange

### DIFF
--- a/vscode-dark-plus-theme.el
+++ b/vscode-dark-plus-theme.el
@@ -172,7 +172,7 @@
    `(org-level-2                              ((,class (:bold nil :foreground ,ms-lightblue))))
    `(org-level-3                              ((,class (:bold nil :foreground ,ms-blue))))
    `(org-level-4                              ((,class (:bold nil :foreground ,ms-bluegreen))))
-   `(org-code                                 ((,class (:foreground ,fg2))))
+   `(org-code                                 ((,class (:foreground ,ms-orange))))
    `(org-hide                                 ((,class (:foreground ,fg4))))
    `(org-date                                 ((,class (:underline t :foreground ,var) )))
    `(org-footnote                             ((,class (:underline t :foreground ,fg4))))
@@ -195,7 +195,7 @@
    `(org-scheduled-today                      ((,class (:foreground ,func :weight normal
                                                                     ,@(when vscode-dark-plus-scale-org-faces (list :height 1.2))))))
    `(org-ellipsis                             ((,class (:foreground ,builtin))))
-   `(org-verbatim                             ((,class (:foreground ,fg4))))
+   `(org-verbatim                             ((,class (:foreground ,ms-lightorange))))
    `(org-document-title                       ((,class (:foreground ,type :bold t
                                                                     ,@(when vscode-dark-plus-scale-org-faces (list :height 1.2)))))) ; title
    `(org-document-info                        ((,class (:foreground ,ms-yellow)))) ; author, date etc.


### PR DESCRIPTION
#24 

Final appearance:
![image](https://user-images.githubusercontent.com/14101781/126280752-d66038fb-aee5-45bc-9436-83fd6811873e.png)
