### PR TITLE
Fix foreground color of org-hide

### DIFF
--- a/vscode-dark-plus-theme.el
+++ b/vscode-dark-plus-theme.el
@@ -201,7 +201,7 @@
    `(org-level-7                              ((,class (:bold nil :foreground ,ms-lightorange))))
    `(org-level-8                              ((,class (:bold nil :foreground ,ms-red))))
    `(org-code                                 ((,class (:foreground ,ms-orange))))
-   `(org-hide                                 ((,class (:foreground ,fg4))))
+   `(org-hide                                 ((,class (:foreground ,bg1))))
    `(org-date                                 ((,class (:underline t :foreground ,var) )))
    `(org-footnote                             ((,class (:underline t :foreground ,fg4))))
    `(org-link                                 ((,class (:underline t :foreground ,type ))))


### PR DESCRIPTION
Hi and thanks for the theme!

Running `M-x describe-face` and choosing `org-hide` will give us the following description:
```
Face used to hide leading stars in headlines.
The foreground color of this face should be equal to the background
color of the frame.
```
Currently, setting `org-hide-leading-stars` to `t` doesn't hide leading stars. This PR fixes that.