### PR TITLE
Fix face error on emacs 30.1 - Fixes #39

### DIFF
--- a/vscode-dark-plus-theme.el
+++ b/vscode-dark-plus-theme.el
@@ -209,7 +209,7 @@
    `(org-block                                ((,class (:foreground ,fg2 :background ,bg0 :extend t))))
    `(org-quote                                ((,class (:inherit org-block :slant italic))))
    `(org-verse                                ((,class (:inherit org-block :slant italic))))
-   `(org-todo                                 ((,class (,@(when vscode-dark-plus-box-org-todo (list :box '(:line-width 1 :color ,ms-lightred)))
+   `(org-todo                                 ((,class (,@(when vscode-dark-plus-box-org-todo (list :box `(:line-width 1 :color ,ms-lightred)))
                                                         :foreground ,ms-lightred :bold nil))))
    `(org-done                                 ((,class (:box (:line-width 1 :color ,ms-lightgreen) :foreground ,ms-lightgreen :bold nil ))))
    `(org-warning                              ((,class (:underline t :foreground ,warning))))


### PR DESCRIPTION
The following error was encountered with emacs 30.1 (see #39)

set-face-attribute: Invalid face box: :line-width, 1, :color, (\, ms-lightred)

We could see that the one of the commas was not evaluated in the spliced section.
Changing the quote to a backquote seems to work for me.